### PR TITLE
Add Ruby 3.0 in CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, head]
+        ruby: [2.5, 2.6, 2.7, 3.0, head]
     env:
       RAILS_ENV: test
     steps:

--- a/savon.gemspec
+++ b/savon.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "nori",     "~> 2.4"
   s.add_dependency "httpi",    "~> 2.4.5"
-  s.add_dependency "wasabi",   "~> 3.4"
+  s.add_dependency "wasabi",   "~> 3.6"
   s.add_dependency "akami",    "~> 1.2"
   s.add_dependency "gyoku",    "~> 1.2"
   s.add_dependency "builder",  ">= 2.1.2"


### PR DESCRIPTION
**What kind of change is this?**

Feature: Add Ruby 3.0.0

<!-- E.g. a bugfix, feature, refactoring, build change, etc… -->

**Summary of changes**

Version of [3.6](https://github.com/savonrb/wasabi/releases/tag/v3.6.0) in Wasabi removes `URI.unescape` and `URI.escape` that are deprecated in Ruby 2.7 and Removed in Ruby 3.0. Instead of this is adding an extra dependacy in [addressable](https://github.com/sporkmonger/addressable).

If not at least wasabi 3.6 version is enforced Savon usage can break in Ruby 3.0.0 .
